### PR TITLE
add index.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./package/redis-cache.js');


### PR DESCRIPTION
The project's `package.json` specifies `index.js` as its entry-point, but there is no index.js in the project. This means that the package can't actually be `require`'d by node.

Fixes #1 
