### PR TITLE
Split dependencies between normal/dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "url": "https://github.com/Wildhoney/RedisCache/issues"
   },
   "dependencies": {
+    "q": "~0.9.7",
+    "redis": "2.6.2"
+  },
+  "devDependencies": {
     "express": "~3.4.3",
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-jshint": "~0.7.0",
-    "q": "~0.9.7",
-    "redis": "2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "express": "~3.4.3",
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-jshint": "~0.7.0",
+    "grunt-contrib-jshint": "~0.7.0"
   }
 }


### PR DESCRIPTION
This package only depends on `q` and `redis`, all other dependencies belong `devDependecies` so it won't get installed on production releases. 